### PR TITLE
[FIX] website_sale_customer_type: modal closing with 'ESC' key

### DIFF
--- a/website_sale_customer_type/views/website_sale_templates.xml
+++ b/website_sale_customer_type/views/website_sale_templates.xml
@@ -11,7 +11,7 @@
 
     <!-- Customer Type Selector -->
     <template id="customer_type_selector_popover" name="Customer Type Selector Popover">
-        <div id="customer_type_selector" class="modal" tabindex="-1" role="dialog" data-backdrop="static">
+        <div id="customer_type_selector" class="modal" tabindex="-1" role="dialog" data-backdrop="static" data-keyboard="false">
             <div class="modal-dialog modal-lg" role="document">
                 <div class="modal-content">
                     <div class="modal-body">


### PR DESCRIPTION
[TASK](https://gestion.coopiteasy.be/web#id=6076&view_type=form&model=project.task&action=479)
Prevent the modal window from being closed with the escape key
Source : https://stackoverflow.com/a/30243352