### PR TITLE
[11.0][ADD] website_sale_customer_type: payment acquirer configuration

### DIFF
--- a/website_sale_customer_type/README.rst
+++ b/website_sale_customer_type/README.rst
@@ -27,6 +27,8 @@ A Customer Type brings functionality to :
 
 - Restrict products that a customer can view on the e-commerce to a list
   of allowed products.
+- Restrict acquirers that a customer can use on the e-commerce to a list
+  of allowed acquirers.
 - Force the customer to login before accessing to the e-commerce.
 - Redirect the customer to a specific location after the selection of
   its type (see Customer Type Selector Popover).
@@ -79,6 +81,20 @@ Customer Type*.
 
 To enable the Customer Selector on the e-commerce, it must exists at
 least one Customer Type with the *Show On Website* property set to True.
+
+
+Acquirer Restriction
+~~~~~~~~~~~~~~~~~~~~
+
+On the Customer Type, the `website_restrict_acquirer` field should
+be set to `True` **and** the field `website_acquirer_ids` should be
+filled with some acquirers. When the `website_restrict_acquirer` is set,
+the only acquirer that this user will see will be the one in the
+`website_acquirer_ids` list. If this list is empty, the user will see all
+activated/published acquirers.
+
+To assign acquirer to a Customer Type, it can also be done by adding the
+Customer Type directly on the Payment Acquirer form under the *Configuration* tab.
 
 Usage
 =====

--- a/website_sale_customer_type/__manifest__.py
+++ b/website_sale_customer_type/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Website Sale Customer Type',
     'description': """
         Let customer choose his type when accessing the e-commerce""",
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'license': 'AGPL-3',
     'author': 'Coop IT Easy SCRLfs <https://coopiteasy.be>',
     'website': 'https://github.com/coopiteasy/cie-e-commerce',

--- a/website_sale_customer_type/__manifest__.py
+++ b/website_sale_customer_type/__manifest__.py
@@ -16,6 +16,7 @@
     ],
     'data': [
         "views/auth_signup_login_templates.xml",
+        "views/payment_views.xml",
         "views/portal_templates.xml",
         "views/product_product.xml",
         "views/res_partner.xml",

--- a/website_sale_customer_type/controllers/main.py
+++ b/website_sale_customer_type/controllers/main.py
@@ -329,3 +329,52 @@ class WebsiteSale(Base):
                 request.env["res.partner.customer.type"].sudo().browse(int(request.session["customer_type"]))
                 )
         return result
+
+    def _get_shop_payment_values(self, order, **kwargs):
+        result = super(WebsiteSale, self)._get_shop_payment_values(
+            order, **kwargs
+        )
+        shipping_partner_id = False
+        if order:
+            shipping_partner_id = (
+                order.partner_shipping_id.id or order.partner_invoice_id.id
+            )
+        allowed_acquirers = {}
+        if request.env.user.website_restrict_acquirer:
+            allowed_acquirers = request.env.user.website_acquirer_ids
+
+        form_acquirers = [
+            acq
+            for acq in allowed_acquirers
+            if acq.payment_flow == "form" and acq.view_template_id
+        ]
+        s2s_acquirers = [
+            acq
+            for acq in allowed_acquirers
+            if acq.payment_flow == "s2s" and acq.registration_view_template_id
+        ]
+
+        for acq in form_acquirers:
+            acq.form = (
+                acq.with_context(
+                    submit_class="btn btn-primary", submit_txt=_("Pay Now")
+                )
+                    .sudo()
+                    .render(
+                    "/",
+                    order.amount_total,
+                    order.pricelist_id.currency_id.id,
+                    values={
+                        "return_url": "/shop/payment/validate",
+                        "partner_id": shipping_partner_id,
+                        "billing_partner_id": order.partner_invoice_id.id,
+                    },
+                )
+            )
+
+        if form_acquirers:
+            result["form_acquirers"] = form_acquirers
+        if s2s_acquirers:
+            result["s2s_acquirers"] = s2s_acquirers
+
+        return result

--- a/website_sale_customer_type/models/__init__.py
+++ b/website_sale_customer_type/models/__init__.py
@@ -2,3 +2,4 @@ from . import res_partner_customer_type
 from . import res_partner
 from . import res_users
 from . import product_product
+from . import payment_acquirer

--- a/website_sale_customer_type/models/payment_acquirer.py
+++ b/website_sale_customer_type/models/payment_acquirer.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class PaymentAcquirer(models.Model):
+    _inherit = "payment.acquirer"
+
+    customer_type_ids = fields.Many2many(
+        string="Supported Customer Types",
+        comodel_name="res.partner.customer.type",
+        columns2="website_acquirer_ids",
+        help="Customer Types having this Acquirer enabled",
+    )

--- a/website_sale_customer_type/models/res_partner.py
+++ b/website_sale_customer_type/models/res_partner.py
@@ -25,6 +25,15 @@ class ResPartner(models.Model):
         string="Product",
         compute="_compute_website_product_ids",
     )
+    website_restrict_acquirer = fields.Boolean(
+        string="Restrict Acquirer on E-commerce",
+        compute="_compute_website_restrict_acquirer"
+    )
+    website_acquirer_ids = fields.Many2many(
+        comodel_name="payment.acquirer",
+        string="Acquirer",
+        compute="_compute_website_acquirer_ids",
+    )
 
     def get_customer_type_id(self):
         """
@@ -63,3 +72,30 @@ class ResPartner(models.Model):
             ):
                 products |= partner.get_customer_type_id().website_product_ids
             partner.website_product_ids = products
+
+    @api.depends("customer_type_id")
+    def _compute_website_restrict_acquirer(self):
+        """
+        Set website_restrict_acquirer to True if the customer type
+        has the flag website_restrict_acquirer set.
+        """
+        for partner in self:
+            partner.website_restrict_acquirer = (
+                partner.get_customer_type_id()
+                and partner.get_customer_type_id().website_restrict_acquirer
+            )
+
+    @api.depends("customer_type_id")
+    def _compute_website_acquirer_ids(self):
+        """
+        Return the list of acquirer that can be seen on the e-commerce by
+        the partner if connected depending on its customer type.
+        """
+        for partner in self:
+            acquirers = self.env["payment.acquirer"]
+            if (
+                partner.get_customer_type_id()
+                and partner.get_customer_type_id().website_acquirer_ids
+            ):
+                acquirers |= partner.get_customer_type_id().website_acquirer_ids
+            partner.website_acquirer_ids = acquirers

--- a/website_sale_customer_type/models/res_partner_customer_type.py
+++ b/website_sale_customer_type/models/res_partner_customer_type.py
@@ -64,6 +64,17 @@ class ResPartnerCustomerType(models.Model):
         default="A TIN/VAT number is required for this customer type",
         translate=True
     )
+    website_restrict_acquirer = fields.Boolean(
+        string="Restrict Acquirer on E-commerce"
+    )
+    website_acquirer_ids = fields.Many2many(
+        string="Acquirers",
+        comodel_name="payment.acquirer",
+        columns2="customer_type_ids",
+        domain=[('website_published', '=', True)],
+        help="Acquirers enabled for this Customer Type"
+    )
+
 
     def show_on_website_button(self):
         """Toggle function used for the button in the form"""

--- a/website_sale_customer_type/readme/CONFIGURE.rst
+++ b/website_sale_customer_type/readme/CONFIGURE.rst
@@ -33,3 +33,17 @@ Customer Type*.
 
 To enable the Customer Selector on the e-commerce, it must exists at
 least one Customer Type with the *Show On Website* property set to True.
+
+
+Acquirer Restriction
+~~~~~~~~~~~~~~~~~~~~
+
+On the Customer Type, the `website_restrict_acquirer` field should
+be set to `True` **and** the field `website_acquirer_ids` should be
+filled with some acquirers. When the `website_restrict_acquirer` is set,
+the only acquirer that this user will see will be the one in the
+`website_acquirer_ids` list. If this list is empty, the user will see all
+activated/published acquirers.
+
+To assign acquirer to a Customer Type, it can also be done by adding the
+Customer Type directly on the Payment Acquirer form under the *Configuration* tab.

--- a/website_sale_customer_type/readme/DESCRIPTION.rst
+++ b/website_sale_customer_type/readme/DESCRIPTION.rst
@@ -6,6 +6,8 @@ A Customer Type brings functionality to :
 
 - Restrict products that a customer can view on the e-commerce to a list
   of allowed products.
+- Restrict acquirers that a customer can use on the e-commerce to a list
+  of allowed acquirers.
 - Force the customer to login before accessing to the e-commerce.
 - Redirect the customer to a specific location after the selection of
   its type (see Customer Type Selector Popover).

--- a/website_sale_customer_type/static/description/index.html
+++ b/website_sale_customer_type/static/description/index.html
@@ -374,6 +374,8 @@ Type and assign it to partner.</p>
 <ul class="simple">
 <li>Restrict products that a customer can view on the e-commerce to a list
 of allowed products.</li>
+<li>Restrict acquirers that a customer can use on the e-commerce to a list
+of allowed acquirers.</li>
 <li>Force the customer to login before accessing to the e-commerce.</li>
 <li>Redirect the customer to a specific location after the selection of
 its type (see Customer Type Selector Popover).</li>
@@ -387,14 +389,15 @@ page at the first visit of a new customer (if configured).</p>
 <li><a class="reference internal" href="#configuration" id="id1">Configuration</a><ul>
 <li><a class="reference internal" href="#product-restriction" id="id2">Product Restriction</a></li>
 <li><a class="reference internal" href="#customer-type-selector" id="id3">Customer Type Selector</a></li>
+<li><a class="reference internal" href="#acquirer-restriction" id="id4">Acquirer Restriction</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#usage" id="id4">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id5">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id6">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id7">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id8">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id9">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="id5">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id6">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id7">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id8">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id9">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id10">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -429,9 +432,20 @@ Customer Type</em>.</p>
 <p>To enable the Customer Selector on the e-commerce, it must exists at
 least one Customer Type with the <em>Show On Website</em> property set to True.</p>
 </div>
+<div class="section" id="acquirer-restriction">
+<h2><a class="toc-backref" href="#id4">Acquirer Restriction</a></h2>
+<p>On the Customer Type, the <cite>website_restrict_acquirer</cite> field should
+be set to <cite>True</cite> <strong>and</strong> the field <cite>website_acquirer_ids</cite> should be
+filled with some acquirers. When the <cite>website_restrict_acquirer</cite> is set,
+the only acquirer that this user will see will be the one in the
+<cite>website_acquirer_ids</cite> list. If this list is empty, the user will see all
+activated/published acquirers.</p>
+<p>To assign acquirer to a Customer Type, it can also be done by adding the
+Customer Type directly on the Payment Acquirer form under the <em>Configuration</em> tab.</p>
+</div>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id4">Usage</a></h1>
+<h1><a class="toc-backref" href="#id5">Usage</a></h1>
 <p>Configure as show in the configure section. To use it assign a Customer
 Type to your partners.</p>
 <p>If you have published Customer Type, you will see Customer Type Selector
@@ -440,7 +454,7 @@ on the e-commerce page.</p>
 these when logged in with a proper account.</p>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id5">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id6">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/coopiteasy/cie-e-commerce/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -448,21 +462,21 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id6">Credits</a></h1>
+<h1><a class="toc-backref" href="#id7">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id7">Authors</a></h2>
+<h2><a class="toc-backref" href="#id8">Authors</a></h2>
 <ul class="simple">
 <li>Coop IT Easy SCRLfs &lt;<a class="reference external" href="https://coopiteasy.be">https://coopiteasy.be</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id8">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id9">Contributors</a></h2>
 <ul class="simple">
 <li>Rémy Taymans &lt;<a class="reference external" href="mailto:remy&#64;coopiteasy.be">remy&#64;coopiteasy.be</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id9">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id10">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/coopiteasy/cie-e-commerce/tree/11.0/website_sale_customer_type">coopiteasy/cie-e-commerce</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>

--- a/website_sale_customer_type/views/payment_views.xml
+++ b/website_sale_customer_type/views/payment_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="acquirer_form" model="ir.ui.view">
+        <field name="name">payment.acquirer.form</field>
+        <field name="model">payment.acquirer</field>
+        <field name="inherit_id" ref="payment.acquirer_form"/>
+        <field name="arch" type="xml">
+            <field name="payment_icon_ids" position="after">
+                <field name="customer_type_ids" widget="many2many_tags"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/website_sale_customer_type/views/res_partner_customer_type.xml
+++ b/website_sale_customer_type/views/res_partner_customer_type.xml
@@ -20,11 +20,19 @@
                                 options='{"terminology": "archive"}'/>
                         </button>
                     </div>
-                    <h1>
-                        <field name="name" default_focus="1" placeholder="Name"/>
-                    </h1>
-                    <h2>Signup Configuration</h2>
-                        <div class="row mt16 o_settings_container" id="website_signup">
+                    <div class="oe_title">
+                    <h1><field name="name" default_focus="1" placeholder="Name"/></h1>
+                    </div>
+                    <notebook>
+                        <page string="Product">
+                            <group name="website_product">
+                                <field name="website_restrict_product"/>
+                                <field name="website_product_ids"
+                                    attrs="{'invisible': [('website_restrict_product', '=', False)]}"/>
+                            </group>
+                        </page>
+                        <page string="Signup">
+                            <div class="row mt16 o_settings_container" id="website_signup">
                             <div class="col-xs-12 col-md-12 o_setting_box">
                                 <div class="o_setting_left_pane">
                                     <field name="website_restrict_signup"/>
@@ -60,17 +68,22 @@
                                 </div>
                             </div>
                         </div>
-                    <h2>Website Configuration</h2>
-                    <group name="website_config">
-                        <field name="website_require_early_login"/>
-                        <field name="next_url"/>
-                    </group>
-                    <h2>Product Configuration</h2>
-                    <group name="website_product">
-                        <field name="website_restrict_product"/>
-                        <field name="website_product_ids"
-                            attrs="{'invisible': [('website_restrict_product', '=', False)]}"/>
-                    </group>
+                        </page>
+                        <page string="Website">
+                            <group name="website_config">
+                                <field name="website_require_early_login"/>
+                                <field name="next_url"/>
+                            </group>
+                        </page>
+                        <page string="Payment Acquirer">
+                            <group name="acquirer_config">
+                                <field name="website_restrict_acquirer"/>
+                                <field name="website_acquirer_ids"
+                                       attrs="{'invisible': [('website_restrict_acquirer', '=', False)]}"
+                                       widget="many2many_tags"/>
+                            </group>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>


### PR DESCRIPTION
### [Task](https://gestion.coopiteasy.be/web#id=6430&view_type=form&model=project.task&action=475&active_id=201)

Restrict acquirers (`payment.acquirer`) that a customer can use on the e-commerce to a list of allowed acquirers.