### PR TITLE
[ADD] website_sale_customer_type: ecommerce category restriction

### DIFF
--- a/website_sale_customer_type/README.rst
+++ b/website_sale_customer_type/README.rst
@@ -27,6 +27,8 @@ A Customer Type brings functionality to :
 
 - Restrict products that a customer can view on the e-commerce to a list
   of allowed products.
+- Restrict eCommerce Categories that a customer can view on the e-commerce
+  to a list of allowed categories.
 - Restrict acquirers that a customer can use on the e-commerce to a list
   of allowed acquirers.
 - Force the customer to login before accessing to the e-commerce.
@@ -68,6 +70,28 @@ Restriction* topic.
 !Waring! The product are filtered on the e-commerce **only** if the
 customer is logged in !
 
+eCommerce Categories Restriction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To restrict eCommerce Categories that a user can see on the e-commerce,
+a Customer Type should be assigned to the partner associated with the
+User used by the customer. If this partner is a contact of a company,
+the Customer Type should be assigned to the company.
+
+Then on the Customer Type, the `website_restrict_public_categ` field
+should be set to `True` **and** the field `website_public_categ_ids`
+should be filled with some categories.
+When the `website_restrict_public_categ` is set, the only category that
+this user will see will be the one in the `website_public_categ_ids` list.
+If this list is empty, the user will see no category on the e-commerce.
+
+To assign category to a Customer Type, it can also be done by adding the
+Customer Type directly on the eCommerce Categories form under the
+*Website Restriction* topic.
+
+!Warning! The categories are filtered on the e-commerce **only** if the
+customer is logged in !
+
 
 Customer Type Selector
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -105,8 +129,8 @@ Type to your partners.
 If you have published Customer Type, you will see Customer Type Selector
 on the e-commerce page.
 
-If you have configured products on the customer type, you will see only
-these when logged in with a proper account.
+If you have configured products and/or categories on the customer type,
+you will see only these when logged in with a proper account.
 
 Bug Tracker
 ===========
@@ -130,6 +154,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Rémy Taymans <remy@coopiteasy.be>
+* Vincent Van Rossem <vincent@coopiteasy.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/website_sale_customer_type/__manifest__.py
+++ b/website_sale_customer_type/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Website Sale Customer Type',
     'description': """
         Let customer choose his type when accessing the e-commerce""",
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.2.0',
     'license': 'AGPL-3',
     'author': 'Coop IT Easy SCRLfs <https://coopiteasy.be>',
     'website': 'https://github.com/coopiteasy/cie-e-commerce',
@@ -19,6 +19,7 @@
         "views/payment_views.xml",
         "views/portal_templates.xml",
         "views/product_product.xml",
+        "views/product_public_category.xml",
         "views/res_partner.xml",
         "views/res_partner_customer_type.xml",
         "views/website_sale_templates.xml",

--- a/website_sale_customer_type/models/__init__.py
+++ b/website_sale_customer_type/models/__init__.py
@@ -3,3 +3,4 @@ from . import res_partner
 from . import res_users
 from . import product_product
 from . import payment_acquirer
+from . import product_public_category

--- a/website_sale_customer_type/models/product_public_category.py
+++ b/website_sale_customer_type/models/product_public_category.py
@@ -1,0 +1,20 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import fields, models, api
+
+
+class ProductPublicCategory(models.Model):
+    _inherit = 'product.public.category'
+
+    is_display_stand = fields.Boolean(
+        string="Is A Display Stand?"
+    )
+    customer_type_ids = fields.Many2many(
+        string="Restricted by Customer Types",
+        comodel_name="res.partner.customer.type",
+        columns2="website_public_categ_ids",
+        help=(
+            "This product appears in restriction list of the following "
+            "customer type"
+        )
+    )

--- a/website_sale_customer_type/models/res_partner_customer_type.py
+++ b/website_sale_customer_type/models/res_partner_customer_type.py
@@ -75,6 +75,19 @@ class ResPartnerCustomerType(models.Model):
         help="Acquirers enabled for this Customer Type"
     )
 
+    website_restrict_public_categ = fields.Boolean(
+        string="Restrict Product Category on E-commerce"
+    )
+    website_public_categ_ids = fields.Many2many(
+        string="eCommerce Category",
+        comodel_name="product.public.category",
+        columns2="customer_type_ids",
+        help=(
+            "Choose product category that can be viewed on e-commerce by users "
+            "that belongs to this customer type."
+        )
+    )
+
 
     def show_on_website_button(self):
         """Toggle function used for the button in the form"""

--- a/website_sale_customer_type/readme/CONFIGURE.rst
+++ b/website_sale_customer_type/readme/CONFIGURE.rst
@@ -20,6 +20,28 @@ Restriction* topic.
 !Waring! The product are filtered on the e-commerce **only** if the
 customer is logged in !
 
+eCommerce Categories Restriction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To restrict eCommerce Categories that a user can see on the e-commerce,
+a Customer Type should be assigned to the partner associated with the
+User used by the customer. If this partner is a contact of a company,
+the Customer Type should be assigned to the company.
+
+Then on the Customer Type, the `website_restrict_public_categ` field
+should be set to `True` **and** the field `website_public_categ_ids`
+should be filled with some categories.
+When the `website_restrict_public_categ` is set, the only category that
+this user will see will be the one in the `website_public_categ_ids` list.
+If this list is empty, the user will see no category on the e-commerce.
+
+To assign category to a Customer Type, it can also be done by adding the
+Customer Type directly on the eCommerce Categories form under the
+*Website Restriction* topic.
+
+!Warning! The categories are filtered on the e-commerce **only** if the
+customer is logged in !
+
 
 Customer Type Selector
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/website_sale_customer_type/readme/CONTRIBUTORS.rst
+++ b/website_sale_customer_type/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Rémy Taymans <remy@coopiteasy.be>
+* Vincent Van Rossem <vincent@coopiteasy.be>

--- a/website_sale_customer_type/readme/DESCRIPTION.rst
+++ b/website_sale_customer_type/readme/DESCRIPTION.rst
@@ -6,6 +6,8 @@ A Customer Type brings functionality to :
 
 - Restrict products that a customer can view on the e-commerce to a list
   of allowed products.
+- Restrict eCommerce Categories that a customer can view on the e-commerce
+  to a list of allowed categories.
 - Restrict acquirers that a customer can use on the e-commerce to a list
   of allowed acquirers.
 - Force the customer to login before accessing to the e-commerce.

--- a/website_sale_customer_type/readme/USAGE.rst
+++ b/website_sale_customer_type/readme/USAGE.rst
@@ -4,5 +4,5 @@ Type to your partners.
 If you have published Customer Type, you will see Customer Type Selector
 on the e-commerce page.
 
-If you have configured products on the customer type, you will see only
-these when logged in with a proper account.
+If you have configured products and/or categories on the customer type,
+you will see only these when logged in with a proper account.

--- a/website_sale_customer_type/static/description/index.html
+++ b/website_sale_customer_type/static/description/index.html
@@ -374,6 +374,8 @@ Type and assign it to partner.</p>
 <ul class="simple">
 <li>Restrict products that a customer can view on the e-commerce to a list
 of allowed products.</li>
+<li>Restrict eCommerce Categories that a customer can view on the e-commerce
+to a list of allowed categories.</li>
 <li>Restrict acquirers that a customer can use on the e-commerce to a list
 of allowed acquirers.</li>
 <li>Force the customer to login before accessing to the e-commerce.</li>
@@ -388,16 +390,17 @@ page at the first visit of a new customer (if configured).</p>
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="id1">Configuration</a><ul>
 <li><a class="reference internal" href="#product-restriction" id="id2">Product Restriction</a></li>
-<li><a class="reference internal" href="#customer-type-selector" id="id3">Customer Type Selector</a></li>
-<li><a class="reference internal" href="#acquirer-restriction" id="id4">Acquirer Restriction</a></li>
+<li><a class="reference internal" href="#ecommerce-categories-restriction" id="id3">eCommerce Categories Restriction</a></li>
+<li><a class="reference internal" href="#customer-type-selector" id="id4">Customer Type Selector</a></li>
+<li><a class="reference internal" href="#acquirer-restriction" id="id5">Acquirer Restriction</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#usage" id="id5">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id6">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id7">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id8">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id9">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id10">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="id6">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id7">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id8">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id9">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id10">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id11">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -422,8 +425,26 @@ Restriction</em> topic.</p>
 <p>!Waring! The product are filtered on the e-commerce <strong>only</strong> if the
 customer is logged in !</p>
 </div>
+<div class="section" id="ecommerce-categories-restriction">
+<h2><a class="toc-backref" href="#id3">eCommerce Categories Restriction</a></h2>
+<p>To restrict eCommerce Categories that a user can see on the e-commerce,
+a Customer Type should be assigned to the partner associated with the
+User used by the customer. If this partner is a contact of a company,
+the Customer Type should be assigned to the company.</p>
+<p>Then on the Customer Type, the <cite>website_restrict_public_categ</cite> field
+should be set to <cite>True</cite> <strong>and</strong> the field <cite>website_public_categ_ids</cite>
+should be filled with some categories.
+When the <cite>website_restrict_public_categ</cite> is set, the only category that
+this user will see will be the one in the <cite>website_public_categ_ids</cite> list.
+If this list is empty, the user will see no category on the e-commerce.</p>
+<p>To assign category to a Customer Type, it can also be done by adding the
+Customer Type directly on the eCommerce Categories form under the
+<em>Website Restriction</em> topic.</p>
+<p>!Warning! The categories are filtered on the e-commerce <strong>only</strong> if the
+customer is logged in !</p>
+</div>
 <div class="section" id="customer-type-selector">
-<h2><a class="toc-backref" href="#id3">Customer Type Selector</a></h2>
+<h2><a class="toc-backref" href="#id4">Customer Type Selector</a></h2>
 <p>By default, this module don’t show a Customer Selector on the
 e-commerce. The goal of the Customer Selector is to let the user choose
 his type of customer a be guided to the right procedure to connect.</p>
@@ -433,7 +454,7 @@ Customer Type</em>.</p>
 least one Customer Type with the <em>Show On Website</em> property set to True.</p>
 </div>
 <div class="section" id="acquirer-restriction">
-<h2><a class="toc-backref" href="#id4">Acquirer Restriction</a></h2>
+<h2><a class="toc-backref" href="#id5">Acquirer Restriction</a></h2>
 <p>On the Customer Type, the <cite>website_restrict_acquirer</cite> field should
 be set to <cite>True</cite> <strong>and</strong> the field <cite>website_acquirer_ids</cite> should be
 filled with some acquirers. When the <cite>website_restrict_acquirer</cite> is set,
@@ -445,16 +466,16 @@ Customer Type directly on the Payment Acquirer form under the <em>Configuration<
 </div>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id5">Usage</a></h1>
+<h1><a class="toc-backref" href="#id6">Usage</a></h1>
 <p>Configure as show in the configure section. To use it assign a Customer
 Type to your partners.</p>
 <p>If you have published Customer Type, you will see Customer Type Selector
 on the e-commerce page.</p>
-<p>If you have configured products on the customer type, you will see only
-these when logged in with a proper account.</p>
+<p>If you have configured products and/or categories on the customer type,
+you will see only these when logged in with a proper account.</p>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id6">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id7">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/coopiteasy/cie-e-commerce/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -462,21 +483,22 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id7">Credits</a></h1>
+<h1><a class="toc-backref" href="#id8">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id8">Authors</a></h2>
+<h2><a class="toc-backref" href="#id9">Authors</a></h2>
 <ul class="simple">
 <li>Coop IT Easy SCRLfs &lt;<a class="reference external" href="https://coopiteasy.be">https://coopiteasy.be</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id9">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id10">Contributors</a></h2>
 <ul class="simple">
 <li>Rémy Taymans &lt;<a class="reference external" href="mailto:remy&#64;coopiteasy.be">remy&#64;coopiteasy.be</a>&gt;</li>
+<li>Vincent Van Rossem &lt;<a class="reference external" href="mailto:vincent&#64;coopiteasy.be">vincent&#64;coopiteasy.be</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id10">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id11">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/coopiteasy/cie-e-commerce/tree/11.0/website_sale_customer_type">coopiteasy/cie-e-commerce</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>

--- a/website_sale_customer_type/views/product_public_category.xml
+++ b/website_sale_customer_type/views/product_public_category.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_public_category_form_view" model="ir.ui.view">
+        <field name="name">product.public.category.website.sale.customer.type.form</field>
+        <field name="model">product.public.category</field>
+        <field name="inherit_id" ref="website_sale.product_public_category_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']/../.." position="after">
+                <group name="is_display_stand">
+                    <field name="is_display_stand"/>
+                </group>
+                <group name="website_restriction" string="Website Restriction">
+                    <field name="customer_type_ids"
+                           widget="many2many_tags"/>
+                </group>
+            </xpath>
+
+        </field>
+    </record>
+</odoo>

--- a/website_sale_customer_type/views/res_partner_customer_type.xml
+++ b/website_sale_customer_type/views/res_partner_customer_type.xml
@@ -83,6 +83,13 @@
                                        widget="many2many_tags"/>
                             </group>
                         </page>
+                        <page string="eCommerce Category" name="public_categ">
+                            <group name="website_public_categ">
+                                <field name="website_restrict_public_categ"/>
+                                <field name="website_public_categ_ids"
+                                    attrs="{'invisible': [('website_restrict_public_categ', '=', False)]}"/>
+                            </group>
+                        </page>
                     </notebook>
                 </sheet>
             </form>


### PR DESCRIPTION
### [Task](https://gestion.coopiteasy.be/web#id=6046&view_type=form&model=project.task&action=479)

Add eCommerce Category Restriction
![website_sale_customer_type_ecommerce_category](https://user-images.githubusercontent.com/28013700/130821325-5c5c05a1-c56a-4781-9721-c0417b7c0457.png)

Add `is_display_stand` to `product.public.category`. 
This field will be used to know if the eCommerce category refers to a Display Stand or not. 
Module `cet_website_sale` uses this field to display a list view on a display stand category (cf. https://github.com/coopiteasy/cycle-en-terre/pull/87)

![website_sale_customer_type_ecommerce_categories_display_stand](https://user-images.githubusercontent.com/28013700/130822020-97105e2a-2ffe-4035-b9a9-d7ad24d0c3fa.png)
