### PR TITLE
[FIX] w_s_customer_type: filter product variant when on a product page

### DIFF
--- a/website_sale_customer_type/controllers/main.py
+++ b/website_sale_customer_type/controllers/main.py
@@ -304,6 +304,10 @@ class WebsiteSale(Base):
             )
         else:
             alt_product_ids = product.alternative_product_ids
+        response.qcontext["allowed_products"] = allowed_products
+        response.qcontext["restrict_product"] = (
+            request.env.user.website_restrict_product
+        )
         response.qcontext["alt_product_ids"] = alt_product_ids
         return response
 


### PR DESCRIPTION
[task](https://gestion.coopiteasy.be/web#id=6548&view_type=form&model=project.task&action=479)

There is a mess in the 12.0 version. This patch should be applie in 12.0 also.